### PR TITLE
hdmidongle: enable mxcuart0 and 1

### DIFF
--- a/arch/arm/mach-mx6/board-mx6q_hdmidongle.c
+++ b/arch/arm/mach-mx6/board-mx6q_hdmidongle.c
@@ -114,6 +114,8 @@ static const struct anatop_thermal_platform_data
 
 static inline void mx6q_hdmidongle_init_uart(void)
 {
+	imx6q_add_imx_uart(0, NULL);
+	imx6q_add_imx_uart(1, NULL);
 	imx6q_add_imx_uart(2, NULL);
 	imx6q_add_imx_uart(3, NULL);
 }


### PR DESCRIPTION
bluetooth is on ttymxc1; you should be able to use hciattach to bring the HCI online.
